### PR TITLE
Switch to three-dots icon on sidebar toggle button

### DIFF
--- a/src/ui/Sidebar.jsx
+++ b/src/ui/Sidebar.jsx
@@ -111,9 +111,9 @@ function SidebarToggle() {
       className="border-color navbar-background absolute left-[16rem] right-12 top-10 z-40 flex h-10 w-[2.25rem] items-center justify-center rounded-r-lg border-y border-r"
       onClick={toggleSidebarOpen}
     >
-      <FaAngleLeft
+      <PiDotsThreeVerticalBold
         className={`translate-animation h-8 w-8 fill-slate-800 dark:fill-slate-300 ${
-          !isSidebarOpen && 'rotate-180'
+          !isSidebarOpen && 'rotate-90'
         }`}
       />
     </button>


### PR DESCRIPTION
Current arrow icon causes some confusion because it also looks like a page changing button. It would be better to switch to the three-dots icon to eliminate any confusion.

![image](https://github.com/tunapotur/react-portfolio/assets/57146234/281adeb9-3512-4e69-a25f-6e084cdbbe8d)
